### PR TITLE
Technical/decimal lifting

### DIFF
--- a/HappyTravel.Money/Extensions/DecimalExtensions.cs
+++ b/HappyTravel.Money/Extensions/DecimalExtensions.cs
@@ -1,0 +1,15 @@
+﻿using HappyTravel.Money.Enums;
+using HappyTravel.Money.Models;
+
+namespace HappyTravel.Money.Extensions
+{
+    public static class DecimalExtensions
+    {
+        public static MoneyAmount ToMoneyAmount(this decimal target, in Currencies targetCurrency) 
+            => new(target, targetCurrency);
+
+
+        public static MoneyAmount ToMoneyAmount(this decimal target, in MoneyAmount targetAmount) 
+            => new(target, targetAmount.Currency);
+    }
+}

--- a/HappyTravel.Money/HappyTravel.Money.csproj
+++ b/HappyTravel.Money/HappyTravel.Money.csproj
@@ -8,7 +8,7 @@
         <RepositoryUrl>https://github.com/happy-travel/money</RepositoryUrl>
         <PackageReleaseNotes>Drop support 3.1 target framework; added initial properties</PackageReleaseNotes>
         <Nullable>enable</Nullable>
-        <Version>1.2.0</Version>
+        <Version>1.2.1</Version>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>

--- a/HappyTravel.Money/Models/MoneyAmount.cs
+++ b/HappyTravel.Money/Models/MoneyAmount.cs
@@ -16,7 +16,7 @@ namespace HappyTravel.Money.Models
         public static MoneyAmount operator +(in MoneyAmount a) => a;
 
 
-        public static MoneyAmount operator -(in MoneyAmount a) => new MoneyAmount(-a.Amount, a.Currency);
+        public static MoneyAmount operator -(in MoneyAmount a) => new (-a.Amount, a.Currency);
 
 
         public static MoneyAmount operator +(in MoneyAmount a, in MoneyAmount b)


### PR DESCRIPTION
An extension to create more readable conversions between decimals and MoneyAmounts. I.e. 
```csharp
decimal discountedPrice = (price / 100) * discount; 
var amount = discountedPrice.ToMoneyAmount(Currencies.USD);
```
instead of 
```csharp
var amount = new MoneyAmount
{
    Amount = (price / 100) * discount,
    Currency = Currencies.USD
}
```